### PR TITLE
chore: debump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MultiAgentPathFinding"
 uuid = "1f5aa91a-953b-4f4c-bed6-d21f3af349fa"
 authors = ["Guillaume Dalle"]
-version = "0.5.3"
+version = "0.5.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"


### PR DESCRIPTION
Was erroneously bumped to 0.5.3 before releasing 0.5.2